### PR TITLE
Changes to allow for commit search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         pip install flake8 pytest
         python -m pip install .
 
+    - name: Set up git
+      run: |
+        git config --global user.name "runner"
+        git config --global user.email "runner@github"
+
     - name: Lint
       run: |
         # Peform basic lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Run tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        python -m pip install .
+
+    - name: Lint
+      run: |
+        # Peform basic lints
+        flake8 . --count --select=E9,F63,F7 --show-source --statistics
+
+    - name: Test
+      run: |
+        pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 .pypirc
 .package.lock
 .tox/
+*.egg-info
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Git Wrapper
 
 The Simple Python Git Wrapper
+---
+[![PyPI version](https://badge.fury.io/py/python-git-wrapper.svg)](https://pypi.org/project/python-git-wrapper/)
 
 This library is a simple git wrapper which let you perform many operations on any git repository in a powerful and simple way.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Small overview about the capabilities of this library. All this methods and attr
 | execute  | execute any git command in the repository | str |
 | revert_last_commit  | Generate a new commit reverting the previous one  | Commit |
 | change_last_commit_message  | Rewrite the previous commit message  | Commit |
+| get_commit  | Retrieve Commit by hash in the repository  |  Commit |
 | get_commit_by_position  | Retrieve Commit by position in the current branch  |  Commit |
+| get_commit_children  | Retrieve Commits that HEAD contributed towards  |  Commit |
+| get_commit_parents  | Retrieve Commits that contributed towards HEAD  |  Commit |
 | get_branches_by_commit  | Retrieve all the branches which contain one specific commit | Commit  |
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,7 +56,7 @@ Push the changes to your remote repository.
 
 **remote_branch**: str
     Remote branch destination of the changes. **Optional** Default to upstream branch
-    
+
 **local_branch**: str
     Local branch source of your changes. If you don't specify it will use your current branch. **Optional** Default Current Branch
 
@@ -106,9 +106,9 @@ Create a new branch
 **Returns** -> Status
 
 ---
-`def merge_branches((self, branch_origin: Branch, branch: Branch, squash=False, new_commit=False) -> Branch`
+`def merge_branches((self, branch_origin: Branch, branch: Branch, squash=False, fast_forward=True, new_commit=False) -> Branch`
 
-Merge one branch into another one. **TAKE CARE** This library doesn't support confflict resolution. the status structure would provide troubles in that situation, if your project is prune to conflicts don't use it.
+Merge one branch into another one. **TAKE CARE** This library doesn't support conflict resolution. the status structure would provide troubles in that situation, if your project is prune to conflicts don't use it.
 
 **branch_origin**: str
     Base branch to the merge. **Mandatory**
@@ -118,6 +118,9 @@ Merge one branch into another one. **TAKE CARE** This library doesn't support co
 
 **squash**: boolean
     Flag to indicate you want to merge using squash mode. **Optional** Default to False
+
+**fast_forward**: boolean
+    Flag to indicate you want to merge using fast-forward only. **Optional** Default to True
 
 **new_commit**: boolean
     Flag to indicate you want to create a new commit with the merge. **Optional** Default to False
@@ -168,6 +171,16 @@ Rewrite the previous commit with the new message specified.
 **Returns** -> Commit
 
 ---
+`* def get_commit(self, hash: str) -> Commit`
+
+Retrieve a commit by its hash in the repository.
+
+**hash**: str
+    Hash of the commit you want to retrieve. **Mandatory**
+
+**Returns** -> Commit
+
+---
 `* def get_commit_by_position(self, position: int) -> Commit`
 
 Retrieve a commit by its position in the branch.
@@ -176,6 +189,26 @@ Retrieve a commit by its position in the branch.
     Position of the commit you want to retrieve. **Mandatory**
 
 **Returns** -> Commit
+
+---
+`* def get_commit_children(self, commit: Commit) -> List[Commit]`
+
+Returns the commits that immediately build of the given commit.
+
+**commit**: commit
+    The commit to query. **Mandatory**
+
+**Returns** -> List[Commit]
+
+---
+`* def get_commit_parents(self, commit: Commit) -> List[Commit]`
+
+Returns the commits that immediately contributed to the given commit.
+
+**commit**: commit
+    The commit to query. **Mandatory**
+
+**Returns** -> List[Commit]
 
 ---
 `* def get_branches_by_commit(self, commit: Commit) -> List[Branch]`

--- a/python_git_wrapper/commit.py
+++ b/python_git_wrapper/commit.py
@@ -2,12 +2,13 @@ import datetime
 
 
 class Commit:
-
-    def __init__(self, hash: str, message: str, date_time: datetime.datetime, author: str):
+    def __init__(self, hash: str, message: str, date_time: datetime.datetime,
+                 author: str, repository: 'Repository'):
         self._hash = hash
         self.message = message
         self.datetime = date_time
         self.author = author
+        self._repository = repository
 
     @property
     def hash(self):
@@ -15,13 +16,26 @@ class Commit:
 
     @hash.setter
     def hash(self, value):
-        raise Exception('There is no possible set a new hash value, instance a new commit instead')
+        raise Exception(
+            'There is no possible set a new hash value, instance a new commit instead'
+        )
+
+    @property
+    def children(self):
+        return self._repository.get_commit_children(self.hash)
+
+    @property
+    def parents(self):
+        return self._repository.get_commit_parents(self.hash)
+
+    def __repr__(self):
+        return self.__str__()
 
     def __str__(self):
         return self._hash
 
-    def __hash__(self) -> str:
-        return self._hash
+    def __hash__(self) -> int:
+        return self._hash.__hash__()
 
     def __eq__(self, other: 'Commit') -> bool:
         return self.hash == other.hash

--- a/python_git_wrapper/commit.py
+++ b/python_git_wrapper/commit.py
@@ -18,7 +18,7 @@ class Commit:
     @hash.setter
     def hash(self, value):
         raise Exception(
-            'There is no possible set a new hash value, instance a new commit instead'
+            'It is not possible to set a new hash value, instance a new commit instead'
         )
 
     @property

--- a/python_git_wrapper/commit.py
+++ b/python_git_wrapper/commit.py
@@ -3,11 +3,12 @@ import datetime
 
 class Commit:
     def __init__(self, hash: str, message: str, date_time: datetime.datetime,
-                 author: str, repository: 'Repository'):
+            author: str, email: str, repository: 'Repository'):
         self._hash = hash
         self.message = message
         self.datetime = date_time
         self.author = author
+        self.email = email
         self._repository = repository
 
     @property

--- a/python_git_wrapper/exceptions.py
+++ b/python_git_wrapper/exceptions.py
@@ -13,5 +13,6 @@ class RepositoryNotFoundError(RepositoryException):
 class RepositoryEmpty(RepositoryException):
     message = 'Repository does not have any commits yet'
 
+
 class StatusError(GitError):
     message = 'Error serializing the status'

--- a/python_git_wrapper/repository.py
+++ b/python_git_wrapper/repository.py
@@ -161,9 +161,9 @@ class Repository:
     def get_commit(self, hash: str) -> Commit:
 
         last_log = self.execute(
-            f'show {hash} --pretty=format:"%H{DELIMITER}%an{DELIMITER}%ad{DELIMITER}%s" --date=iso -s'
+            f'show {hash} --pretty=format:"%H{DELIMITER}%an{DELIMITER}%ad{DELIMITER}%ae{DELIMITER}%s" --date=iso -s'
         ).replace('"', '')
-        chash, cauthor, cdate_time, cmessage = last_log.split(DELIMITER)
+        chash, cauthor, cdate_time, cemail, cmessage = last_log.split(DELIMITER)
 
         cdate_time = datetime.datetime.strptime(cdate_time,
                                                 '%Y-%m-%d %H:%M:%S %z')
@@ -171,6 +171,7 @@ class Repository:
             hash=chash,
             author=cauthor,
             date_time=cdate_time,
+            email=cemail,
             message=cmessage,
             repository=self)
 

--- a/python_git_wrapper/repository.py
+++ b/python_git_wrapper/repository.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import List, Tuple
+from typing import List
 
 import datetime
 
@@ -9,15 +9,7 @@ from python_git_wrapper.commit import Commit
 from python_git_wrapper.exceptions import RepositoryNotFoundError, RepositoryEmpty
 from python_git_wrapper.git_service import GitService
 from python_git_wrapper.status import Status
-
-DELIMITER = '¡|&'
-
-
-def join_flags(flags: List[Tuple[bool, str]]):
-    return "".join([flag for (flagged, flag) in flags if flagged])
-
-
-get_hash = lambda commits: set(commit.hash for commit in commits)
+from python_git_wrapper.utils import DELIMITER, get_hash, join_flags
 
 
 class Repository:

--- a/python_git_wrapper/utils.py
+++ b/python_git_wrapper/utils.py
@@ -1,0 +1,11 @@
+from typing import List, Tuple
+
+DELIMITER = '¡|&'
+
+
+def join_flags(flags: List[Tuple[bool, str]]):
+    return "".join([flag for (flagged, flag) in flags if flagged])
+
+
+def get_hash(commits):
+    return set(commit.hash for commit in commits)

--- a/tests/git_service/test_git_service.py
+++ b/tests/git_service/test_git_service.py
@@ -7,7 +7,7 @@ from python_git_wrapper.git_service import GitService
 
 
 def test_create_git_service():
-    service = GitService.singleton('/usr/local/bin/git')
+    service = GitService.singleton()
     assert isinstance(service, GitService)
 
     service = GitService.instance()
@@ -20,7 +20,7 @@ def test_create_git_service_using_wrong_path():
 
 
 def test_run_git_command():
-    GitService.singleton('/usr/local/bin/git')
+    GitService.singleton()
 
     response = GitService.run_git_command('--version')
 
@@ -31,7 +31,7 @@ def test_run_git_command():
 
 
 def test_run_git_command_using_wrong_command():
-    GitService.singleton('/usr/local/bin/git')
+    GitService.singleton()
 
     with pytest.raises(GitError):
         GitService.run_git_command('--v')

--- a/tests/repository/test_commits.py
+++ b/tests/repository/test_commits.py
@@ -37,7 +37,5 @@ def test_merge_commit_ancestors(repository_with_commits: Repository):
     branch_merged = repository_with_commits.merge_branches(
         origin_branch, branch2, new_commit=True, fast_forward=False)
 
-    print(repository_with_commits.execute("l"))
-
     assert {random_commit_list[-1], random_commit_list2[-1]} == set(repository_with_commits.last_commit.parents)
     assert {random_commit_list[0], random_commit_list2[0]} == set(initial_commit.children)

--- a/tests/repository/test_commits.py
+++ b/tests/repository/test_commits.py
@@ -1,0 +1,43 @@
+import pytest
+
+from python_git_wrapper import GitError
+from python_git_wrapper.branch import Branch
+from python_git_wrapper.commit import Commit
+from python_git_wrapper.repository import Repository
+from tests.fixtures.repository import repository_with_commits, create_random_commit
+
+pytest.mark.usefixtures(repository_with_commits)
+
+
+def test_get_current_commit(repository_with_commits: Repository):
+    commit = repository_with_commits.last_commit
+    assert not commit.children
+    assert not commit.parents
+    new_commit = create_random_commit(repository_with_commits)
+    assert set(new_commit.parents) == {commit}
+    assert repository_with_commits.last_commit == new_commit
+
+
+def test_merge_commit_ancestors(repository_with_commits: Repository):
+    initial_commit = repository_with_commits.last_commit
+
+    origin_branch = Branch('master')
+    branch_name2 = 'test_branch2'
+
+    branch2 = repository_with_commits.create_branch(branch_name2, move_to=True)
+    random_commit_list = [
+        create_random_commit(repository_with_commits) for i in range(4)
+    ]
+
+    repository_with_commits.checkout(origin_branch)
+    random_commit_list2 = [
+        create_random_commit(repository_with_commits) for i in range(4)
+    ]
+
+    branch_merged = repository_with_commits.merge_branches(
+        origin_branch, branch2, new_commit=True, fast_forward=False)
+
+    print(repository_with_commits.execute("l"))
+
+    assert {random_commit_list[-1], random_commit_list2[-1]} == set(repository_with_commits.last_commit.parents)
+    assert {random_commit_list[0], random_commit_list2[0]} == set(initial_commit.children)


### PR DESCRIPTION
See #5 

From a given head, one can now traverse the git commit graph with `commit.children` and `commit.parents`

I threw in a couple other tweaks (v minor), but I can remove them